### PR TITLE
Add `update-changelog` composite actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A collection of reusable **GitHub Actions composite workflows** for [Flockyn](ht
 ## Available Actions
 
 - [`create-release`](./actions/create-release) – Create GitHub releases with cleaned notes.
+- [`update-changelog`](./actions/update-changelog) – Update `CHANGELOG.md` during releases.
 
 ## Changelog
 

--- a/actions/update-changelog/README.md
+++ b/actions/update-changelog/README.md
@@ -1,0 +1,26 @@
+# Update Changelog
+
+Composite action to automatically update `CHANGELOG.md` during release.
+
+## Inputs
+
+- `branch`: Branch to compare for recent changes (default: `github.ref_name`)
+- `changelog-file`: Path to changelog file (default: `CHANGELOG.md`)
+- `version`: Version number to add to the changelog (e.g., v1.0.0)
+- `notes`: Release notes to add to the changelog
+
+## Example usage
+
+```yaml
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: flockyn/workflows/actions/update-changelog@v1
+        with:
+          version: v1.0.0
+          notes: "Initial release"
+          changelog-file: CHANGELOG.md
+          branch: main
+```

--- a/actions/update-changelog/action.yml
+++ b/actions/update-changelog/action.yml
@@ -1,0 +1,56 @@
+name: Update Changelog
+description: Update the changelog file with recent changes
+author: Candra Sudirman
+
+inputs:
+  branch:
+    description: Branch to compare for recent changes
+    required: false
+    default: ${{ github.ref_name }}
+    type: string
+  changelog-file:
+    description: Path to the changelog file
+    required: false
+    default: CHANGELOG.md
+    type: string
+  version:
+    description: Version number to add to the changelog (e.g., v1.0.0)
+    required: true
+    type: string
+  notes:
+    description: Release notes to add to the changelog
+    required: true
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Check file exists
+      if: ${{ hashFiles(inputs.changelog-file) == '' }}
+      uses: actions/github-script@v7
+      with:
+        script: |
+          core.setFailed(`Changelog file "${{ inputs.changelog-file }}" does not exist.`);
+
+    - name: Extract release date from git tag
+      id: release-date
+      run: ${{ github.action_path }}/scripts/release-date.sh
+      env:
+        VERSION: ${{ inputs.version }}
+      shell: bash
+    
+    - name: Update changelog
+      uses: stefanzweifel/changelog-updater-action@v1
+      with:
+        release-date: ${{ steps.release-date.outputs.date }}
+        release-notes: ${{ inputs.notes }}
+        latest-version: ${{ inputs.version }}
+        compare-url-target-revision: ${{ inputs.branch }}
+        parse-github-usernames: true
+    
+    - name: Commit updated CHANGELOG
+      uses: stefanzweifel/git-auto-commit-action@v4
+      with:
+        branch: ${{ inputs.branch }}
+        commit_message: Update CHANGELOG
+        file_pattern: ${{ inputs.changelog-file }}

--- a/actions/update-changelog/scripts/release-date.sh
+++ b/actions/update-changelog/scripts/release-date.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Get UNIX timestamp from git-tag
+TIMESTAMP_OF_RELEASE_COMMIT=$(git log -1 --date=unix --format=%ad "$VERSION");
+
+# Convert timestamp to UTC date in Y-m-d format
+FORMATED_DATE=$(date -u -d "@$TIMESTAMP_OF_RELEASE_COMMIT" +%Y-%m-%d);
+
+# Make date available to other steps
+echo "date=$(echo $FORMATED_DATE)" >> $GITHUB_OUTPUT;


### PR DESCRIPTION
This pull request adds a composite GitHub action to update the CHANGELOG