### PR TITLE
Add `php-tests` composite actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A collection of reusable **GitHub Actions composite workflows** for [Flockyn](ht
 ## Available Actions
 
 - [`create-release`](./actions/create-release) – Create GitHub releases with cleaned notes.
+- [`php-tests`](./actions/php-tests) – Run unit test for PHP projects.
 - [`update-changelog`](./actions/update-changelog) – Update `CHANGELOG.md` during releases.
 
 ## Changelog

--- a/actions/php-tests/README.md
+++ b/actions/php-tests/README.md
@@ -1,0 +1,30 @@
+# PHP Tests
+
+Composite action to run unit test for PHP projects.
+
+## Inputs
+
+- `php-version`: PHP version to use (default: `8.2`)
+- `extensions`: PHP extensions to install (comma-separated)
+- `coverage`: Code coverage driver (`none`, `xdebug`, or `pcov`)
+- `composer-cmd`: Composer command to install dependencies (`install` or `update`, default: `install`) with flags
+- `execute-cmd`: Command to run tests (default: `vendor/bin/phpunit`)
+
+> [!NOTE]
+> This action uses [shivammathur/setup-php](https://github.com/shivammathur/setup-php) under the hood for PHP installation and configuration.
+> Refer to its documentation for advanced options (`php-version`, `extensions`, and `coverage`).
+
+## Usage
+
+```yaml
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: flockyn/workflows/actions/php-tests@v1
+        with:
+          php-version: '8.2'
+          coverage: xdebug
+          extensions: mbstring, intl
+```

--- a/actions/php-tests/action.yml
+++ b/actions/php-tests/action.yml
@@ -1,0 +1,55 @@
+name: PHP Tests
+description: Run unit test for PHP projects
+author: Candra Sudirman
+
+inputs:
+  php-version:
+    description: PHP version to use
+    required: false
+    default: '8.2'
+    type: string
+  extensions:
+    description: PHP extensions to install (comma-separated)
+    required: false
+    default: ''
+    type: string
+  coverage:
+    description: Code coverage driver (none, xdebug, or pcov)
+    required: false
+    default: ''
+    type: string
+  composer-cmd:
+    description: Composer command to install dependencies (install, update) with flags
+    required: false
+    default: install
+    type: choice
+    options:
+      - install
+      - update
+  execute-cmd:
+    description: Command to run tests
+    required: false
+    default: vendor/bin/phpunit
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ inputs.php-version }}
+        extensions: ${{ inputs.extensions }}
+        coverage: ${{ inputs.coverage }}
+    
+    - name: Validate composer.json and composer.lock
+      run: composer validate
+      shell: bash
+    
+    - name: Install Dependencies
+      run: composer ${{ inputs.composer-cmd }} --prefer-dist --no-progress --no-interaction
+      shell: bash
+
+    - name: Execute Tests
+      run: ${{ inputs.execute-cmd }}
+      shell: bash


### PR DESCRIPTION
This pull request adds a composite GitHub action to run unit testing for PHP projects.