### PR TITLE
Add `php-analysis` composite actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ A collection of reusable **GitHub Actions composite workflows** for [Flockyn](ht
 ## Available Actions
 
 - [`create-release`](./actions/create-release) – Create GitHub releases with cleaned notes.
+- [`php-analysis`](./actions/php-analysis) – Run PHPStan static analysis.
 - [`php-style`](./actions/php-style) – Run PHP CS Fixer to ensure consistent coding style.
 - [`php-tests`](./actions/php-tests) – Run unit test for PHP projects.
 - [`update-changelog`](./actions/update-changelog) – Update `CHANGELOG.md` during releases.

--- a/actions/php-analysis/README.md
+++ b/actions/php-analysis/README.md
@@ -1,0 +1,23 @@
+# PHP Analysis
+
+Composite to run PHPStan analysis for PHP Projects.
+
+## Inputs
+
+- `php-version`: PHP version to use (default: `8.2`)
+- `extensions`: PHP extensions to install (comma-separated)
+- `config`: Path to PHPStan configuration file (default: `phpstan.neon`)
+
+## Usage
+
+```yaml
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: flockyn/workflows/actions/php-analysis@v1
+        with:
+          php-version: '8.2'
+          config: 'phpstan.dist.neon'
+```

--- a/actions/php-analysis/action.yml
+++ b/actions/php-analysis/action.yml
@@ -1,0 +1,34 @@
+name: PHP Analysis
+description: Run PHPStan static analysis
+author: Candra Sudirman
+
+inputs:
+  php-version:
+    description: PHP version to use
+    required: false
+    default: '8.2'
+    type: string
+  extensions:
+    description: PHP extensions to install (comma-separated)
+    required: false
+    default: ''
+    type: string
+  config:
+    description: Path to PHPStan configuration file
+    required: false
+    default: 'phpstan.neon'
+    type: string
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        tools: phpstan
+        php-version: ${{ inputs.php-version }}
+        extensions: ${{ inputs.extensions }}
+
+    - name: Run Static Analysis
+      run: phpstan analyse --no-progress --configuration="${{ inputs.config }}"
+      shell: bash


### PR DESCRIPTION
This pull request adds a composite GitHub action to run PHPStan static analysis.