### PR TITLE
Adjust `php-analysis` with introduce `composer-cmd`

### DIFF
--- a/actions/php-analysis/README.md
+++ b/actions/php-analysis/README.md
@@ -6,6 +6,7 @@ Composite to run PHPStan analysis for PHP Projects.
 
 - `php-version`: PHP version to use (default: `8.2`)
 - `extensions`: PHP extensions to install (comma-separated)
+- `composer-cmd`: Composer command to install dependencies (`install` or `update`, default: `install`) with flags
 - `config`: Path to PHPStan configuration file (default: `phpstan.neon`)
 
 ## Usage

--- a/actions/php-analysis/action.yml
+++ b/actions/php-analysis/action.yml
@@ -13,6 +13,14 @@ inputs:
     required: false
     default: ''
     type: string
+  composer-cmd:
+    description: Composer command to install dependencies (install, update) with flags
+    required: false
+    default: install
+    type: choice
+    options:
+      - install
+      - update
   config:
     description: Path to PHPStan configuration file
     required: false
@@ -28,6 +36,14 @@ runs:
         tools: phpstan
         php-version: ${{ inputs.php-version }}
         extensions: ${{ inputs.extensions }}
+
+    - name: Validate composer.json and composer.lock
+      run: composer validate
+      shell: bash
+
+    - name: Install Dependencies
+      run: composer ${{ inputs.composer-cmd }} --prefer-dist --no-progress --no-interaction
+      shell: bash
 
     - name: Run Static Analysis
       run: phpstan analyse --no-progress --configuration="${{ inputs.config }}"


### PR DESCRIPTION
This pull request adds a new input `composer-cmd` into `php-analysis` and adds new steps `validate composer` and `execute composer command`.